### PR TITLE
Added ability to use both FileType and arbitrary mime-type

### DIFF
--- a/FPlib/build.gradle
+++ b/FPlib/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 
@@ -19,12 +19,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionName project.VERSION_NAME
         versionCode Integer.parseInt(project.VERSION_CODE)
     }
@@ -39,8 +39,8 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile project(':materialfabmenu')
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.android.support:cardview-v7:22.0.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:cardview-v7:22.2.1'
     compile 'com.afollestad:material-dialogs:0.7.6.0'
     compile 'com.nispok:snackbar:2.10.6'
 }

--- a/FPlib/src/main/java/com/devpaul/filepickerlibrary/enums/FileType.java
+++ b/FPlib/src/main/java/com/devpaul/filepickerlibrary/enums/FileType.java
@@ -20,5 +20,18 @@ package com.devpaul.filepickerlibrary.enums;
  * Created by Paul Tsouchlos
  */
 public enum FileType {
-    NONE,JPEG,JPG,PNG,XML,XLS,XLSX,DOC,DOCX,HTML,TXT, PDF
+    NONE(""), JPEG("image/jpeg"), JPG("image/jpeg"), PNG("image/png"), XML("application/xml"),
+    XLS("application/vnd.ms-excel"), XLSX("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    DOC("application/msword"), DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    HTML("text/html"), TXT("text/plain"), PDF("application/pdf");
+
+    private String mimeType;
+
+    FileType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
     defaultConfig {
         applicationId 'com.devpaul.filepicker'
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName '1.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/materialfabmenu/build.gradle
+++ b/materialfabmenu/build.gradle
@@ -8,17 +8,17 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
     }
@@ -32,5 +32,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 }


### PR DESCRIPTION
Couple of updates:
* Added the ability to use either the built in "FileType" enum, or an arbitrary mime type for file selection.  The code is backwardly compatible but better fits the OO "open/closed" principle now, as you'll not need to modify the code when someone wants to support selecting (say) iCal ".ics" format files.

* Updated the build-tools and target versions to 22

* Updated the android plugin version to 1.2.3

* Updated app-compat (and cardview) version to 22.2.1

Sorry about the large number of changed lines - I did a reformat code as part of the commit process - ignore whitespace and things ought to be reasonably clear.